### PR TITLE
Waiting error handled properly now

### DIFF
--- a/Sources/Engine/WSEngine.swift
+++ b/Sources/Engine/WSEngine.swift
@@ -143,9 +143,7 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
             let wsReq = HTTPWSHeader.createUpgrade(request: request, supportsCompression: framer.supportsCompression(), secKeyValue: secKeyValue)
             let data = httpHandler.convert(request: wsReq)
             transport.write(data: data, completion: {_ in })
-        case .waiting:
-            break
-        case .failed(let error):
+        case .waiting(let error), .failed(let error):
             handleError(error)
         case .viability(let isViable):
             broadcast(event: .viabilityChanged(isViable))

--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -110,8 +110,8 @@ public class TCPTransport: Transport {
             switch newState {
             case .ready:
                 self?.delegate?.connectionChanged(state: .connected)
-            case .waiting:
-                self?.delegate?.connectionChanged(state: .waiting)
+            case .waiting(let error):
+                self?.delegate?.connectionChanged(state: .waiting(error))
             case .cancelled:
                 self?.delegate?.connectionChanged(state: .cancelled)
             case .failed(let error):

--- a/Sources/Transport/Transport.swift
+++ b/Sources/Transport/Transport.swift
@@ -27,7 +27,7 @@ public enum ConnectionState {
     case connected
     
     /// Waiting connections have not yet been started, or do not have a viable network
-    case waiting
+    case waiting(Error?)
     
     /// Cancelled connections have been invalidated by the client and will send no more events
     case cancelled


### PR DESCRIPTION
Waiting state, when connection is suddenly lost, now handled properly.

Copy of
https://github.com/daltoniam/Starscream/pull/772
and
https://github.com/daltoniam/Starscream/pull/821